### PR TITLE
Display nyan progress when zoning ends

### DIFF
--- a/zone-nyan.el
+++ b/zone-nyan.el
@@ -743,13 +743,17 @@ It fires every 100ms.")
 (defvar zone-nyan-progress 0
   "Holds the current progress of the timer.")
 
+(defun zone-nyan-report-progress ()
+  "Report current nyan progress."
+  (message "You've nyaned for %.1f seconds"
+           (/ zone-nyan-progress 10.0)))
+
 (defun zone-nyan-progress ()
   "Progress function.
 It informs the user just how many seconds they've wasted on
 watching nyan cat run."
   (unless zone-nyan-hide-progress
-    (message "You've nyaned for %.1f seconds"
-             (/ zone-nyan-progress 10.0)))
+    (zone-nyan-report-progress))
   (setq zone-nyan-progress (1+ zone-nyan-progress)))
 
 ;;;###autoload
@@ -784,7 +788,9 @@ watching nyan cat run."
       (when zone-nyan-bg-music-process
         (delete-process zone-nyan-bg-music-process))
       (when zone-nyan-progress-timer
-        (cancel-timer zone-nyan-progress-timer)))))
+        (cancel-timer zone-nyan-progress-timer)
+        (when zone-nyan-hide-progress
+            (zone-nyan-report-progress))))))
 
 ;;;###autoload
 (defun zone-nyan-preview ()


### PR DESCRIPTION
Although some may turn off continuous progress report, it is still an important information how long have you been nyanned.
